### PR TITLE
More output

### DIFF
--- a/src/main/java/com/soebes/maven/plugins/licenseverifier/AbstractLicenseVerifierPlugIn.java
+++ b/src/main/java/com/soebes/maven/plugins/licenseverifier/AbstractLicenseVerifierPlugIn.java
@@ -98,6 +98,14 @@ public abstract class AbstractLicenseVerifierPlugIn extends AbstractMojo {
     private boolean verbose;
 
     /**
+     * This will turn on explicit licence information in
+     * error, warning and info messages.
+     *
+     * @parameter expression="${mlv.explicitLicenceInfo}" default-value="false"
+     */
+    private boolean explicitLicenceInfo;
+
+    /**
      * This will turn on strictChecking behavior which
      * will check URL and Name of a license instead of
      * only URL or Name.
@@ -299,5 +307,13 @@ public abstract class AbstractLicenseVerifierPlugIn extends AbstractMojo {
 
     public boolean isVerbose() {
         return verbose;
+    }
+
+    public boolean isExplicitLicenceInfo() {
+        return explicitLicenceInfo;
+    }
+
+    public void setExplicitLicenceInfo(boolean explicitLicenceInfo) {
+        this.explicitLicenceInfo = explicitLicenceInfo;
     }
 }

--- a/src/main/java/com/soebes/maven/plugins/licenseverifier/LicenseVerifierMojo.java
+++ b/src/main/java/com/soebes/maven/plugins/licenseverifier/LicenseVerifierMojo.java
@@ -52,26 +52,26 @@ public class LicenseVerifierMojo extends AbstractLicenseVerifierPlugIn {
         if (licenseData.hasValid()) {
             for (LicenseInformation item : licenseData.getValid()) {
                 if (isVerbose()) {
-                    getLog().info("   ]VALID[   (" + item.getArtifact().getScope() + ") The artifact " + item.getProject().getId() + " has a license which is categorized as valid");
+                    getLog().info(createLogString(6, item, "]VALID[", "valid"));
                 }
             }
         }
 
         if (licenseData.hasInvalid()) {
             for (LicenseInformation item : licenseData.getInvalid()) {
-                getLog().error("  ]INVALID[ (" + item.getArtifact().getScope() + ") The artifact " + item.getProject().getId() + " has a license which is categorized as invalid");
+                getLog().error(createLogString(7, item, "]INVALID[", "invalid"));
             }
         }
 
         if (licenseData.hasWarning()) {
             for (LicenseInformation item : licenseData.getWarning()) {
-                getLog().warn("]WARNING[ (" + item.getArtifact().getScope() + ") The artifact " + item.getProject().getId() + " has a license which is categorized as warning");
+                getLog().warn(createLogString(9, item, "]WARNING[", "warning"));
             }
         }
 
         if (licenseData.hasUnknown()) {
             for (LicenseInformation item : licenseData.getUnknown()) {
-                getLog().warn("]UNKNOWN[ (" + item.getArtifact().getScope() + ") The artifact " + item.getProject().getId() + " has a license which is categorized as unknown");
+                getLog().warn(createLogString(9, item, "]UNKNOWN[", "unknown"));
             }
         }
 
@@ -92,4 +92,44 @@ public class LicenseVerifierMojo extends AbstractLicenseVerifierPlugIn {
         }
     }
 
+    private String createLogString(int logLevelLength, LicenseInformation item, String prefix, String status) {
+        StringBuilder log = new StringBuilder();
+
+        for(int i = 0; i < (9 - logLevelLength); i++) {
+            log.append(" ");
+        }
+
+        log.append(prefix);
+
+        for(int i = 0; i < (10 - prefix.length()); i++) {
+            log.append(" ");
+        }
+
+        log.append("(");
+        log.append(item.getArtifact().getScope());
+        log.append(") The artifact ");
+        log.append(item.getProject().getId());
+        log.append(" has a license ");
+        if (isExplicitLicenceInfo()) {
+            StringBuilder licenseInfo = new StringBuilder();
+            for(org.apache.maven.model.License license : item.getLicenses()) {
+                licenseInfo.append("\"");
+                licenseInfo.append(license.getName());
+                licenseInfo.append("\" - ");
+                licenseInfo.append(license.getUrl());
+                licenseInfo.append(", ");
+            }
+
+            if (licenseInfo.length() > 2) {
+                log.append("(");
+                log.append(licenseInfo.toString().substring(0, licenseInfo.length() - 2));
+                log.append(") ");
+            }
+        }
+
+        log.append("which is categorized as ");
+        log.append(status);
+
+        return log.toString();
+    }
 }

--- a/src/main/java/com/soebes/maven/plugins/licenseverifier/LicenseVerifierMojo.java
+++ b/src/main/java/com/soebes/maven/plugins/licenseverifier/LicenseVerifierMojo.java
@@ -44,7 +44,7 @@ public class LicenseVerifierMojo extends AbstractLicenseVerifierPlugIn {
         if (licenseData.hasExcludedByConfiguration()) {
             if (isVerbose()) {
                 for (LicenseInformation item : licenseData.getValid()) {
-                    getLog().warn("The artifact: " + item.getArtifact().getId() + " has been execluded by the configuration.");
+                    getLog().warn("The artifact: " + item.getArtifact().getId() + " has been excluded by the configuration.");
                 }
             }
         }


### PR DESCRIPTION
I have added a new configuration parameter, explicitLicenceInfo, to add more explicit license information in messages.

For example:
```
[WARNING] ]UNKNOWN[ (compile) The artifact net.logstash.logback:logstash-logback-encoder:jar:4.11 has a license ("Apache License, Version 2.0" - http://www.apache.org/licenses/LICENSE-2.0, "MIT License" - http://www.slf4j.org/license.html) which is categorized as unknown
```
